### PR TITLE
Add XIAO MG24 microphone USB streaming sketch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
 # AusculSound
+
+This repository contains a simple Arduino sketch for the Seeed Studio XIAO MG24 Sense that streams the on-board analog microphone over USB CDC to a connected PC. The sketch targets the "Seeed Studio MG24 Boards" Arduino core.
+
+## Firmware overview
+
+The sketch samples the microphone connected to pin `PC9` at 16 kHz with a 12-bit resolution. Samples are buffered in blocks of 256 and transmitted over the native USB CDC interface as little-endian 16-bit PCM values. Any serial terminal or host application that can read raw bytes from the virtual COM port can capture the audio stream.
+
+### Key configuration values
+
+- `SAMPLE_RATE_HZ` controls the audio sampling rate (default 16 kHz).
+- `SAMPLES_PER_TRANSFER` adjusts the USB packet size (default 256 samples).
+
+These constants can be tuned in the sketch to match the bandwidth and latency needs of your project.
+
+## Building and uploading
+
+1. Install the **Seeed Studio MG24 Boards** core in the Arduino IDE.
+2. Select **Seeed Studio XIAO MG24** (or XIAO MG24 Sense) as the target board.
+3. Open the sketch located at `firmware/seeed_xiao_mg24_usb_mic/seeed_xiao_mg24_usb_mic.ino`.
+4. Compile and upload the sketch to the board using the Arduino IDE.
+5. Open a serial monitor (or capture program) on the enumerated USB COM port to receive the raw PCM stream.
+
+## Host-side capture
+
+For quick testing on a PC, you can use Python's `pyserial` to record the stream:
+
+```python
+import serial
+import array
+
+port = serial.Serial('COMx', 115200)
+num_samples = 16000  # 1 second at 16 kHz
+pcm = array.array('H', port.read(num_samples * 2))
+```
+
+Replace `COMx` with the actual port name (e.g., `/dev/ttyACM0` on Linux).

--- a/firmware/seeed_xiao_mg24_usb_mic/seeed_xiao_mg24_usb_mic.ino
+++ b/firmware/seeed_xiao_mg24_usb_mic/seeed_xiao_mg24_usb_mic.ino
@@ -1,0 +1,61 @@
+#include <Arduino.h>
+
+// Analog microphone pin for the onboard MEMS microphone.
+// The Seeed XIAO MG24 routes the microphone output to PC9.
+constexpr uint8_t kMicAnalogPin = PC9;
+
+// Audio configuration. Adjust SAMPLE_RATE_HZ to match the bandwidth you need.
+constexpr uint32_t SAMPLE_RATE_HZ = 16000;
+constexpr size_t SAMPLES_PER_TRANSFER = 256;
+
+// Derived constants.
+constexpr uint32_t kSamplePeriodUs = 1000000UL / SAMPLE_RATE_HZ;
+
+// Helper macro to pick the correct USB CDC serial port symbol provided by the
+// Seeed Studio MG24 Arduino core.
+#if defined(USBCDC_SERIAL_PORT)
+#define USB_SERIAL USBCDC_SERIAL_PORT
+#else
+#define USB_SERIAL Serial
+#endif
+
+void setup() {
+  // Initialise the USB CDC interface. The baud rate argument is ignored for
+  // native USB devices but is kept for compatibility with serial monitors.
+  USB_SERIAL.begin(115200);
+  uint32_t start = millis();
+  while (!USB_SERIAL && (millis() - start < 5000)) {
+    delay(10);
+  }
+
+  // Configure the ADC resolution to the native 12 bits of the MG24 and set the
+  // microphone pin as an input.
+  analogReadResolution(12);
+  pinMode(kMicAnalogPin, INPUT);
+
+  USB_SERIAL.println(F("XIAO MG24 microphone streaming over USB CDC"));
+  USB_SERIAL.print(F("Sample rate: "));
+  USB_SERIAL.print(SAMPLE_RATE_HZ);
+  USB_SERIAL.println(F(" Hz"));
+}
+
+void loop() {
+  static uint16_t buffer[SAMPLES_PER_TRANSFER];
+  static size_t writeIndex = 0;
+  static uint32_t nextSampleTimeUs = micros();
+
+  uint32_t now = micros();
+  if ((int32_t)(now - nextSampleTimeUs) >= 0) {
+    nextSampleTimeUs += kSamplePeriodUs;
+
+    // Read the raw 12-bit microphone value (0-4095). The result is stored as a
+    // 16-bit word to simplify transmission as little-endian PCM samples.
+    buffer[writeIndex++] = analogRead(kMicAnalogPin);
+
+    if (writeIndex >= SAMPLES_PER_TRANSFER) {
+      const size_t bytesToWrite = SAMPLES_PER_TRANSFER * sizeof(buffer[0]);
+      USB_SERIAL.write(reinterpret_cast<uint8_t *>(buffer), bytesToWrite);
+      writeIndex = 0;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add an Arduino sketch for the Seeed Studio XIAO MG24 Sense that streams the onboard microphone over USB CDC
- document build and usage steps for the sketch in the repository README

## Testing
- not run (Arduino sketch)

------
https://chatgpt.com/codex/tasks/task_e_68d3c8c2d4608328a74d400a13fd0be4