### PR TITLE
Use DMA microphone driver for USB streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # AusculSound
 
-This repository contains a simple Arduino sketch for the Seeed Studio XIAO MG24 Sense that streams the on-board analog microphone over USB CDC to a connected PC. The sketch targets the "Seeed Studio MG24 Boards" Arduino core.
+This repository contains a simple Arduino sketch for the Seeed Studio XIAO MG24 Sense that streams the on-board analog microphone over USB CDC to a connected PC. The sketch targets the "Seeed Studio MG24 Boards" Arduino core and uses Silicon Labs' `SilabsMicrophoneAnalog` driver for reliable DMA-based sampling.
 
 ## Firmware overview
 
-The sketch samples the microphone connected to pin `PC9` at 16 kHz with a 12-bit resolution. Samples are buffered in blocks of 256 and transmitted over the native USB CDC interface as little-endian 16-bit PCM values. Any serial terminal or host application that can read raw bytes from the virtual COM port can capture the audio stream.
+The sketch captures 12-bit samples from the microphone connected to pin `PC9` using a DMA buffer managed by `SilabsMicrophoneAnalog`. Each block of 256 samples is converted to signed 16-bit PCM and transmitted over the native USB CDC interface. Any serial terminal or host application that can read raw bytes from the virtual COM port can capture the audio stream.
 
 ### Key configuration values
 
@@ -16,10 +16,11 @@ These constants can be tuned in the sketch to match the bandwidth and latency ne
 ## Building and uploading
 
 1. Install the **Seeed Studio MG24 Boards** core in the Arduino IDE.
-2. Select **Seeed Studio XIAO MG24** (or XIAO MG24 Sense) as the target board.
-3. Open the sketch located at `firmware/seeed_xiao_mg24_usb_mic/seeed_xiao_mg24_usb_mic.ino`.
-4. Compile and upload the sketch to the board using the Arduino IDE.
-5. Open a serial monitor (or capture program) on the enumerated USB COM port to receive the raw PCM stream.
+2. Add the **SilabsMicrophoneAnalog** library via the Arduino Library Manager (or copy it into your `libraries` folder).
+3. Select **Seeed Studio XIAO MG24** (or XIAO MG24 Sense) as the target board.
+4. Open the sketch located at `firmware/seeed_xiao_mg24_usb_mic/seeed_xiao_mg24_usb_mic.ino`.
+5. Compile and upload the sketch to the board using the Arduino IDE.
+6. Open a serial monitor (or capture program) on the enumerated USB COM port to receive the raw PCM stream.
 
 ## Host-side capture
 


### PR DESCRIPTION
## Summary
- refactor the sketch to sample the MEMS microphone through the SilabsMicrophoneAnalog DMA driver
- convert each DMA block to signed 16-bit PCM before streaming it over USB CDC
- document the new dependency on the SilabsMicrophoneAnalog library in the README

## Testing
- not run (Arduino sketch)


------
https://chatgpt.com/codex/tasks/task_e_68d4f27749d88328ae018b64a80c61b4