### PR TITLE
Switch MG24 audio capture to Seeed DMA driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
 # AusculSound
 
-This repository contains a simple Arduino sketch for the Seeed Studio XIAO MG24 Sense that streams the on-board analog microphone over USB CDC to a connected PC. The sketch targets the "Seeed Studio MG24 Boards" Arduino core and uses Silicon Labs' `SilabsMicrophoneAnalog` driver for reliable DMA-based sampling.
+This repository contains a simple Arduino sketch for the Seeed Studio XIAO MG24 Sense that streams the on-board analog microphone over USB CDC to a connected PC. The sketch targets the "Seeed Studio MG24 Boards" Arduino core and uses Seeed Studio's `Seeed_Arduino_Mic` DMA driver (included in this repository) for reliable sampling.
 
 ## Firmware overview
 
-The sketch captures 12-bit samples from the microphone connected to pin `PC9` using a DMA buffer managed by `SilabsMicrophoneAnalog`. Each block of 256 samples is converted to signed 16-bit PCM and transmitted over the native USB CDC interface. Any serial terminal or host application that can read raw bytes from the virtual COM port can capture the audio stream.
+The sketch captures 12-bit samples from the microphone connected to pin `PC9` using a DMA buffer managed by the `Seeed_Arduino_Mic` library. Each block of 256 samples is converted to signed 16-bit PCM and transmitted over the native USB CDC interface. Any serial terminal or host application that can read raw bytes from the virtual COM port can capture the audio stream.
 
 ### Key configuration values
 
-- `SAMPLE_RATE_HZ` controls the audio sampling rate (default 16 kHz).
-- `SAMPLES_PER_TRANSFER` adjusts the USB packet size (default 256 samples).
+- `kSampleRateHz` controls the audio sampling rate (default 16 kHz).
+- `NUM_SAMPLES` adjusts the USB packet size (default 256 samples).
 
 These constants can be tuned in the sketch to match the bandwidth and latency needs of your project.
 
 ## Building and uploading
 
 1. Install the **Seeed Studio MG24 Boards** core in the Arduino IDE.
-2. Add the **SilabsMicrophoneAnalog** library via the Arduino Library Manager (or copy it into your `libraries` folder).
+2. Copy the **Seeed_Arduino_Mic** library from `Seeed_Arduino_Mic-master` into your Arduino `libraries` folder (or install it through the Arduino Library Manager).
 3. Select **Seeed Studio XIAO MG24** (or XIAO MG24 Sense) as the target board.
 4. Open the sketch located at `firmware/seeed_xiao_mg24_usb_mic/seeed_xiao_mg24_usb_mic.ino`.
 5. Compile and upload the sketch to the board using the Arduino IDE.

--- a/mictest.py
+++ b/mictest.py
@@ -1,16 +1,27 @@
-import serial
+"""Stream audio from the XIAO MG24 microphone over USB CDC.
+
+The firmware uses the Seeed Arduino Mic DMA driver and streams 16-bit PCM
+blocks. This helper script connects to the enumerated serial port and plays the
+incoming audio via the system's default audio output.
+"""
+
+import time
+
 import numpy as np
+import serial
 import sounddevice as sd
 
 # Serial port where the XIAO MG24 shows up.
 # On Windows it might be "COM3", on Linux "/dev/ttyACM0" or "/dev/ttyUSB0"
-SERIAL_PORT = "COM8"    # <-- change this to match your system
+SERIAL_PORT = "COM8"  # <-- change this to match your system
 BAUDRATE = 921600
-SAMPLE_RATE = 8000
-CHUNK_SAMPLES = 256     # must match firmware's SAMPLES_PER_TRANSFER
+SAMPLE_RATE = 16000
+CHUNK_SAMPLES = 256  # Must match NUM_SAMPLES in the firmware sketch.
 
-# Open serial connection
+# Open serial connection and flush any banner text from the firmware.
 ser = serial.Serial(SERIAL_PORT, BAUDRATE)
+time.sleep(0.5)
+ser.reset_input_buffer()
 
 # Callback to continuously stream audio
 def audio_callback(outdata, frames, time, status):


### PR DESCRIPTION
## Summary
- replace the firmware sketch's Silabs microphone driver with the Seeed_Arduino_Mic DMA driver and adapt buffering to stream PCM safely
- document the new dependency and configuration constants in the README and refresh the Python streaming helper for the DMA-based firmware

## Testing
- python -m compileall mictest.py

------
https://chatgpt.com/codex/tasks/task_e_68d594fcc5e4832891726f12ea939099