### PR TITLE
Silence debug logging during audio streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ The sketch captures 12-bit samples from the microphone connected to pin `PC9` us
 
 - `kSampleRateHz` controls the audio sampling rate (default 16 kHz).
 - `NUM_SAMPLES` adjusts the USB packet size (default 256 samples).
+- `kEnableDebugLogging` toggles verbose serial logging. Leave this set to
+  `false` when streaming audio to avoid interleaving ASCII text with the PCM
+  byte stream, which presents as loud static on the host side.
 
 These constants can be tuned in the sketch to match the bandwidth and latency needs of your project.
 

--- a/mictest.py
+++ b/mictest.py
@@ -27,12 +27,15 @@ ser.reset_input_buffer()
 def audio_callback(outdata, frames, time, status):
     if status:
         print(status)
+    outdata.fill(0)
     # Each sample is 2 bytes (little-endian signed PCM from the firmware)
     expected_bytes = CHUNK_SAMPLES * 2
     raw = ser.read(expected_bytes)
+    if len(raw) != expected_bytes:
+        return
     # Convert to numpy array of signed 16-bit samples
     samples = np.frombuffer(raw, dtype=np.int16)
-    outdata[:len(samples), 0] = samples / 32768.0  # normalize to [-1, 1]
+    outdata[:len(samples), 0] = samples.astype(np.float32) / 32768.0  # normalize to [-1, 1]
 
 # Open an audio output stream
 with sd.OutputStream(


### PR DESCRIPTION
## Summary
- add a compile-time flag to silence debug logging during normal USB audio streaming
- guard the firmware self-tests and statistics behind the new debug logging flag
- harden the host-side streaming script to zero audio buffers and ignore undersized serial reads

## Testing
- python -m compileall mictest.py

------
https://chatgpt.com/codex/tasks/task_e_68d646f3d0e48328a623d9b28ba94b20