### PR TITLE
Fix microphone buffer deletion

### DIFF
--- a/Seeed_Arduino_Mic-master/src/hardware/base_mic.cpp
+++ b/Seeed_Arduino_Mic-master/src/hardware/base_mic.cpp
@@ -32,8 +32,8 @@ MicClass::MicClass(mic_config_t *mic_config)
 
 MicClass::~MicClass()
 {
-  delete buf_0;
-  delete buf_1;
+  delete[] buf_0;
+  delete[] buf_1;
 }
 
 uint8_t MicClass::begin()


### PR DESCRIPTION
## Summary
- replace the MicClass destructor's scalar delete calls with delete[] to correctly release the DMA buffers

## Testing
- arduino-cli compile --fqbn SeeedStudio:mg24:xiao_mg24 firmware/seeed_xiao_mg24_usb_mic *(fails: required board index cannot be downloaded in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6acd4560c8328a061bc69c1112afe