### PR TITLE
Return byte count from MicClass::read

### DIFF
--- a/Seeed_Arduino_Mic-master/src/hardware/base_mic.cpp
+++ b/Seeed_Arduino_Mic-master/src/hardware/base_mic.cpp
@@ -1,5 +1,7 @@
 #include "base_mic.h"
 
+#include <cstring>
+
 MicClass::MicClass(mic_config_t *mic_config)
 {
 
@@ -80,7 +82,7 @@ int MicClass::read(void* buffer, uint8_t buf_count, size_t size)
 
   resume();
 
-  return -1;
+  return static_cast<int>(size);
 }
 
 void MicClass::set_callback(void(*function)(uint16_t *buf, uint32_t buf_len))

--- a/tests/stubs/Arduino.h
+++ b/tests/stubs/Arduino.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+using uint8_t = std::uint8_t;
+using uint16_t = std::uint16_t;
+using uint32_t = std::uint32_t;
+
+inline void pinMode(uint8_t, uint8_t) {}
+inline void digitalWrite(uint8_t, uint8_t) {}
+
+constexpr uint8_t OUTPUT = 0x1;

--- a/tests/test_base_mic.cpp
+++ b/tests/test_base_mic.cpp
@@ -1,0 +1,35 @@
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+
+#include "hardware/base_mic.h"
+
+int main() {
+  mic_config_t config{};
+  config.channel_cnt = 1;
+  config.sampling_rate = 16000;
+  config.buf_size = 4;
+  config.debug_pin = 0;
+
+  MicClass mic(&config);
+
+  for (uint32_t i = 0; i < config.buf_size; ++i) {
+    mic.buf_0[i] = static_cast<uint16_t>(i + 1);
+  }
+
+  std::array<uint16_t, 4> destination{};
+  const size_t bytes_to_copy = destination.size() * sizeof(uint16_t);
+
+  const int result = mic.read(destination.data(), /*buf_count=*/0, bytes_to_copy);
+
+  if (result != static_cast<int>(bytes_to_copy)) {
+    return 1;
+  }
+
+  if (!std::equal(destination.begin(), destination.end(), mic.buf_0)) {
+    return 2;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- update `MicClass::read` to include the proper header and return the number of bytes it copies
- add a lightweight host-side unit test with Arduino stubs to validate the new behavior

## Testing
- g++ -std=c++17 tests/test_base_mic.cpp Seeed_Arduino_Mic-master/src/hardware/base_mic.cpp -Itests/stubs -ISeeed_Arduino_Mic-master/src -o tests/test_base_mic
- ./tests/test_base_mic


------
https://chatgpt.com/codex/tasks/task_e_68d6acd37c108328a46910f19612c9bf