### PR TITLE
Fix MG24 DMA source address increment handling

### DIFF
--- a/Seeed_Arduino_Mic-master/src/hardware/mg24_adc.cpp
+++ b/Seeed_Arduino_Mic-master/src/hardware/mg24_adc.cpp
@@ -78,7 +78,7 @@ uint8_t MG24_ADC_Class::initLDMA() {
         buf_0,
         buf_1,
         (void *)&(IADC0->SCANFIFODATA),
-        true,
+        false,
         _buf_size ,
         dmadrvDataSize2,
         dmaCompleteCallback,


### PR DESCRIPTION
## Summary
- disable source address incrementing in the MG24 DMA ping-pong transfer so the ADC FIFO is read correctly

## Testing
- not run (environment lacks the Seeed Studio MG24 Arduino core and hardware)


------
https://chatgpt.com/codex/tasks/task_e_68d70bcd17cc83288cbbbcb881cf5462