### PR TITLE
Guard debug pin toggles in DMA and PDM handlers

### DIFF
--- a/Seeed_Arduino_Mic-master/src/hardware/dma_adc.cpp
+++ b/Seeed_Arduino_Mic-master/src/hardware/dma_adc.cpp
@@ -116,8 +116,8 @@ void DMAC_1_Handler() {
   if (DMAC->Channel[1].CHINTFLAG.bit.SUSP) {
 
      // Debug: make pin high before copying buffer
-    if (*DMA_ADC_Class::_debug_pin_ptr) {
-    digitalWrite(*DMA_ADC_Class::_debug_pin_ptr, HIGH);
+    if (DMA_ADC_Class::_debug_pin_ptr && *DMA_ADC_Class::_debug_pin_ptr) {
+      digitalWrite(*DMA_ADC_Class::_debug_pin_ptr, HIGH);
     }
 
     // Restart DMAC on channel 1 and clear SUSP interrupt flag
@@ -135,8 +135,8 @@ void DMAC_1_Handler() {
     *DMA_ADC_Class::_buf_count_ptr = (*DMA_ADC_Class::_buf_count_ptr + 1) % 2;
 
     // Debug: make pin low after copying buffer
-    if (*DMA_ADC_Class::_debug_pin_ptr) {
-    digitalWrite(*DMA_ADC_Class::_debug_pin_ptr, LOW);
+    if (DMA_ADC_Class::_debug_pin_ptr && *DMA_ADC_Class::_debug_pin_ptr) {
+      digitalWrite(*DMA_ADC_Class::_debug_pin_ptr, LOW);
     }
   }
 }

--- a/Seeed_Arduino_Mic-master/src/hardware/nrf52840_adc.cpp
+++ b/Seeed_Arduino_Mic-master/src/hardware/nrf52840_adc.cpp
@@ -138,7 +138,7 @@ if (nrf_pdm_event_check(NRF_PDM_EVENT_STARTED)) {
     nrf_pdm_event_clear(NRF_PDM_EVENT_STARTED);
 
     // Debug: make pin high before copying buffer
-    if (*NRF52840_ADC_Class::_debug_pin_ptr) 
+    if (NRF52840_ADC_Class::_debug_pin_ptr && *NRF52840_ADC_Class::_debug_pin_ptr)
         digitalWrite(*NRF52840_ADC_Class::_debug_pin_ptr, HIGH);
 
     // switch to fill
@@ -168,7 +168,7 @@ if (nrf_pdm_event_check(NRF_PDM_EVENT_STARTED)) {
     *NRF52840_ADC_Class::_buf_count_ptr = (*NRF52840_ADC_Class::_buf_count_ptr + 1) % 2;
 
     // Debug: make pin low after copying buffer
-    if (*NRF52840_ADC_Class::_debug_pin_ptr) 
+    if (NRF52840_ADC_Class::_debug_pin_ptr && *NRF52840_ADC_Class::_debug_pin_ptr)
         digitalWrite(*NRF52840_ADC_Class::_debug_pin_ptr, LOW);
 
   } else if (nrf_pdm_event_check(NRF_PDM_EVENT_STOPPED)) {


### PR DESCRIPTION
## Summary
- prevent null pointer dereferences when toggling the optional debug pin in the SAMD DMA handler
- apply the same guard around debug pin toggles in the nRF52840 PDM interrupt handler

## Testing
- not run (hardware-dependent)

------
https://chatgpt.com/codex/tasks/task_e_68d70e941308832898fae3c8df89f5b8