### PR TITLE
Fix serial baud mismatch in host audio test

### DIFF
--- a/mictest.py
+++ b/mictest.py
@@ -13,8 +13,11 @@ import sounddevice as sd
 
 # Serial port where the XIAO MG24 shows up.
 # On Windows it might be "COM3", on Linux "/dev/ttyACM0" or "/dev/ttyUSB0"
+# NOTE: The firmware initializes the USB CDC interface at 115200 baud. Using a
+# different rate here will result in corrupted PCM bytes (heard as loud static)
+# on traditional UART bridges, so keep these values in sync.
 SERIAL_PORT = "COM8"  # <-- change this to match your system
-BAUDRATE = 921600
+BAUDRATE = 115200
 SAMPLE_RATE = 16000
 CHUNK_SAMPLES = 256  # Must match NUM_SAMPLES in the firmware sketch.
 


### PR DESCRIPTION
## Summary
- document the required baud rate for the USB CDC stream
- update the host-side helper script to use the same 115200 baud setting as the firmware to avoid corrupted audio

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d718067aac832886365ff6f56bac5a