### PR TITLE
Fix PCM conversion to prevent audio corruption

### DIFF
--- a/firmware/seeed_xiao_mg24_usb_mic/seeed_xiao_mg24_usb_mic.ino
+++ b/firmware/seeed_xiao_mg24_usb_mic/seeed_xiao_mg24_usb_mic.ino
@@ -406,8 +406,14 @@ static void logPcmStatistics(const int16_t *buffer, size_t samples) {
 }
 
 static int16_t convertAdcSampleToPcm(uint16_t sample) {
-  int32_t value = static_cast<int32_t>(sample);
-  value -= kAdcMidpoint;
-  value <<= kAdcToPcmShift;
-  return static_cast<int16_t>(value);
+  int32_t centered = static_cast<int32_t>(sample) - kAdcMidpoint;
+  int32_t scaled = centered * (1 << kAdcToPcmShift);
+
+  if (scaled > INT16_MAX) {
+    scaled = INT16_MAX;
+  } else if (scaled < INT16_MIN) {
+    scaled = INT16_MIN;
+  }
+
+  return static_cast<int16_t>(scaled);
 }


### PR DESCRIPTION
## Summary
- replace the left shift on signed ADC deltas with a safe multiplication to avoid undefined behaviour
- clamp the scaled PCM values to the 16-bit range to prevent overflow artefacts in the audio stream

## Testing
- not run (no automated tests available)

------
https://chatgpt.com/codex/tasks/task_e_68d718067aac832886365ff6f56bac5a