### PR TITLE
Fix DMA ping-pong buffer selection

### DIFF
--- a/Seeed_Arduino_Mic-master/src/hardware/base_mic.cpp
+++ b/Seeed_Arduino_Mic-master/src/hardware/base_mic.cpp
@@ -92,3 +92,13 @@ void MicClass::set_callback(void(*function)(uint16_t *buf, uint32_t buf_len))
 
 }
 
+uint16_t *MicClass::completed_buffer_from_sequence(unsigned int sequence_no)
+{
+  return (sequence_no % 2u) == 0u ? buf_0_ptr : buf_1_ptr;
+}
+
+uint8_t MicClass::buffer_index_from_sequence(unsigned int sequence_no)
+{
+  return (sequence_no % 2u) == 0u ? 0u : 1u;
+}
+

--- a/Seeed_Arduino_Mic-master/src/hardware/base_mic.h
+++ b/Seeed_Arduino_Mic-master/src/hardware/base_mic.h
@@ -93,6 +93,9 @@ public:
   uint16_t *buf_0;    // ADC results array 0
   uint16_t *buf_1;    // ADC results array 1
 
+  static uint16_t *completed_buffer_from_sequence(unsigned int sequence_no);
+  static uint8_t buffer_index_from_sequence(unsigned int sequence_no);
+
   inline static uint8_t *_buf_count_ptr = NULL;
   inline static uint32_t *_buf_size_ptr = NULL;
   inline static uint16_t *buf_0_ptr = NULL;

--- a/Seeed_Arduino_Mic-master/src/hardware/mg24_adc.cpp
+++ b/Seeed_Arduino_Mic-master/src/hardware/mg24_adc.cpp
@@ -131,9 +131,10 @@ void MG24_ADC_Class::resume(){
 
 static bool dmaCompleteCallback(unsigned int channel, unsigned int sequenceNo, void *userParam){
     if (MG24_ADC_Class::_onReceive) {
-        MG24_ADC_Class::_onReceive((sequenceNo % 2) ? MG24_ADC_Class::buf_0_ptr : MG24_ADC_Class::buf_1_ptr, *MG24_ADC_Class::_buf_size_ptr);
+        uint16_t *completed_buffer = MG24_ADC_Class::completed_buffer_from_sequence(sequenceNo);
+        MG24_ADC_Class::_onReceive(completed_buffer, *MG24_ADC_Class::_buf_size_ptr);
     }
-    *MG24_ADC_Class::_buf_count_ptr = sequenceNo % 2 ? 0 : 1;
+    *MG24_ADC_Class::_buf_count_ptr = MG24_ADC_Class::buffer_index_from_sequence(sequenceNo);
     return true;
 }
 

--- a/tests/test_dma_sequence.cpp
+++ b/tests/test_dma_sequence.cpp
@@ -1,0 +1,54 @@
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+#include "hardware/base_mic.h"
+
+int main() {
+  mic_config_t config{};
+  config.channel_cnt = 1;
+  config.sampling_rate = 16000;
+  config.buf_size = 4;
+  config.debug_pin = 0;
+
+  MicClass mic(&config);
+
+  for (uint32_t i = 0; i < config.buf_size; ++i) {
+    mic.buf_0[i] = static_cast<uint16_t>(i + 1);
+    mic.buf_1[i] = static_cast<uint16_t>((i + 1) * 10);
+  }
+
+  if (MicClass::completed_buffer_from_sequence(0) != mic.buf_0) {
+    return 1;
+  }
+
+  if (MicClass::completed_buffer_from_sequence(1) != mic.buf_1) {
+    return 2;
+  }
+
+  if (MicClass::buffer_index_from_sequence(0) != 0) {
+    return 3;
+  }
+
+  if (MicClass::buffer_index_from_sequence(1) != 1) {
+    return 4;
+  }
+
+  constexpr size_t kBytesToCopy = 4 * sizeof(uint16_t);
+  std::array<uint16_t, 4> destination{};
+
+  *MicClass::_buf_count_ptr = MicClass::buffer_index_from_sequence(0);
+  mic.read(destination.data(), *MicClass::_buf_count_ptr, kBytesToCopy);
+  if (!std::equal(destination.begin(), destination.end(), mic.buf_0)) {
+    return 5;
+  }
+
+  *MicClass::_buf_count_ptr = MicClass::buffer_index_from_sequence(1);
+  mic.read(destination.data(), *MicClass::_buf_count_ptr, kBytesToCopy);
+  if (!std::equal(destination.begin(), destination.end(), mic.buf_1)) {
+    return 6;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add helper utilities in the base microphone class to derive the completed DMA buffer and its index from the DMA sequence number
- use the new helpers in the MG24 DMA completion handler to forward the filled buffer instead of the buffer that is still being written to
- add a unit test that validates the helper logic matches the buffer contents returned by `read`

## Testing
- tests/test_base_mic
- tests/test_dma_sequence

------
https://chatgpt.com/codex/tasks/task_e_68d718067aac832886365ff6f56bac5a