### PR TITLE
Fix DMA callback buffer selection

### DIFF
--- a/Seeed_Arduino_Mic-master/src/hardware/mg24_adc.cpp
+++ b/Seeed_Arduino_Mic-master/src/hardware/mg24_adc.cpp
@@ -130,10 +130,15 @@ void MG24_ADC_Class::resume(){
 }
 
 static bool dmaCompleteCallback(unsigned int channel, unsigned int sequenceNo, void *userParam){
+    const bool evenSequence = (sequenceNo % 2u) == 0u;
+
     if (MG24_ADC_Class::_onReceive) {
-        MG24_ADC_Class::_onReceive((sequenceNo % 2) ? MG24_ADC_Class::buf_0_ptr : MG24_ADC_Class::buf_1_ptr, *MG24_ADC_Class::_buf_size_ptr);
+        MG24_ADC_Class::_onReceive(evenSequence ? MG24_ADC_Class::buf_0_ptr
+                                                : MG24_ADC_Class::buf_1_ptr,
+                                    *MG24_ADC_Class::_buf_size_ptr);
     }
-    *MG24_ADC_Class::_buf_count_ptr = sequenceNo % 2 ? 0 : 1;
+
+    *MG24_ADC_Class::_buf_count_ptr = evenSequence ? 0 : 1;
     return true;
 }
 


### PR DESCRIPTION
## Summary
- ensure the MG24 DMA completion callback forwards the buffer that has just finished recording
- keep the exposed buffer index in sync with the actual buffer handed to the consumer to avoid mixing in partially recorded data

## Testing
- not run (host-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d718067aac832886365ff6f56bac5a