### PR TITLE
Guard PCM conversion against high-bit corruption

### DIFF
--- a/firmware/seeed_xiao_mg24_usb_mic/pcm_conversion.h
+++ b/firmware/seeed_xiao_mg24_usb_mic/pcm_conversion.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>
+#include <climits>
+
+namespace ausculsound {
+
+// The MG24 ADC produces 12-bit unsigned samples that we centre around zero and
+// scale to 16-bit signed PCM for USB transmission.
+constexpr uint8_t kAdcResolutionBits = 12;
+constexpr int16_t kAdcMidpoint = 1 << (kAdcResolutionBits - 1);  // 2048
+constexpr uint8_t kAdcToPcmShift = 16 - kAdcResolutionBits;      // Shift left by 4
+constexpr uint16_t kAdcSampleMask = (1u << kAdcResolutionBits) - 1u;
+
+inline int16_t ConvertAdcSampleToPcm(uint16_t sample) {
+  const uint16_t masked_sample = sample & kAdcSampleMask;
+  int32_t centered = static_cast<int32_t>(masked_sample) - kAdcMidpoint;
+  int32_t scaled = centered * (1 << kAdcToPcmShift);
+
+  if (scaled > INT16_MAX) {
+    scaled = INT16_MAX;
+  } else if (scaled < INT16_MIN) {
+    scaled = INT16_MIN;
+  }
+
+  return static_cast<int16_t>(scaled);
+}
+
+}  // namespace ausculsound
+

--- a/tests/test_pcm_conversion.cpp
+++ b/tests/test_pcm_conversion.cpp
@@ -1,0 +1,32 @@
+#include <cstdint>
+#include <climits>
+
+#include "pcm_conversion.h"
+
+int main() {
+  using namespace ausculsound;
+
+  if (ConvertAdcSampleToPcm(0) != INT16_MIN) {
+    return 1;
+  }
+
+  if (ConvertAdcSampleToPcm(kAdcMidpoint) != 0) {
+    return 2;
+  }
+
+  const int16_t expected_max = ConvertAdcSampleToPcm(kAdcSampleMask);
+  if (expected_max <= 0) {
+    return 3;
+  }
+
+  if (ConvertAdcSampleToPcm(0xFFFFu) != expected_max) {
+    return 4;
+  }
+
+  if (ConvertAdcSampleToPcm(kAdcSampleMask + 1u) != expected_max) {
+    return 5;
+  }
+
+  return 0;
+}
+


### PR DESCRIPTION
## Summary
- mask the MG24 ADC samples before scaling and move the conversion helper into a shared header
- update the USB streaming sketch to reuse the shared conversion constants and helper
- add a regression test that exercises the PCM conversion edge cases

## Testing
- g++ -std=c++17 tests/test_base_mic.cpp Seeed_Arduino_Mic-master/src/hardware/base_mic.cpp -Itests/stubs -ISeeed_Arduino_Mic-master/src -o build_test_base_mic && ./build_test_base_mic
- g++ -std=c++17 tests/test_dma_sequence.cpp Seeed_Arduino_Mic-master/src/hardware/base_mic.cpp -Itests/stubs -ISeeed_Arduino_Mic-master/src -o build_test_dma_sequence && ./build_test_dma_sequence
- g++ -std=c++17 tests/test_pcm_conversion.cpp -Itests/stubs -Ifirmware/seeed_xiao_mg24_usb_mic -o build_test_pcm_conversion && ./build_test_pcm_conversion

------
https://chatgpt.com/codex/tasks/task_e_68d7d1b282cc8328a831abc43baba397