### PR TITLE
Fix DMA buffer mapping for ping-pong sequence

### DIFF
--- a/Seeed_Arduino_Mic-master/src/hardware/base_mic.cpp
+++ b/Seeed_Arduino_Mic-master/src/hardware/base_mic.cpp
@@ -94,11 +94,16 @@ void MicClass::set_callback(void(*function)(uint16_t *buf, uint32_t buf_len))
 
 uint16_t *MicClass::completed_buffer_from_sequence(unsigned int sequence_no)
 {
-  return (sequence_no % 2u) == 0u ? buf_0_ptr : buf_1_ptr;
+  // The Silicon Labs DMADRV ping-pong helper reports the sequence number of the
+  // descriptor that *started* the transfer that just finished.  This means the
+  // freshly completed audio samples live in the opposite buffer from the one
+  // indicated by the sequence number that the ISR receives.
+  const bool completed_primary = (sequence_no % 2u) == 0u;
+  return completed_primary ? buf_1_ptr : buf_0_ptr;
 }
 
 uint8_t MicClass::buffer_index_from_sequence(unsigned int sequence_no)
 {
-  return (sequence_no % 2u) == 0u ? 0u : 1u;
+  return (sequence_no % 2u) == 0u ? 1u : 0u;
 }
 

--- a/tests/test_dma_sequence.cpp
+++ b/tests/test_dma_sequence.cpp
@@ -19,19 +19,19 @@ int main() {
     mic.buf_1[i] = static_cast<uint16_t>((i + 1) * 10);
   }
 
-  if (MicClass::completed_buffer_from_sequence(0) != mic.buf_0) {
+  if (MicClass::completed_buffer_from_sequence(0) != mic.buf_1) {
     return 1;
   }
 
-  if (MicClass::completed_buffer_from_sequence(1) != mic.buf_1) {
+  if (MicClass::completed_buffer_from_sequence(1) != mic.buf_0) {
     return 2;
   }
 
-  if (MicClass::buffer_index_from_sequence(0) != 0) {
+  if (MicClass::buffer_index_from_sequence(0) != 1) {
     return 3;
   }
 
-  if (MicClass::buffer_index_from_sequence(1) != 1) {
+  if (MicClass::buffer_index_from_sequence(1) != 0) {
     return 4;
   }
 
@@ -40,13 +40,13 @@ int main() {
 
   *MicClass::_buf_count_ptr = MicClass::buffer_index_from_sequence(0);
   mic.read(destination.data(), *MicClass::_buf_count_ptr, kBytesToCopy);
-  if (!std::equal(destination.begin(), destination.end(), mic.buf_0)) {
+  if (!std::equal(destination.begin(), destination.end(), mic.buf_1)) {
     return 5;
   }
 
   *MicClass::_buf_count_ptr = MicClass::buffer_index_from_sequence(1);
   mic.read(destination.data(), *MicClass::_buf_count_ptr, kBytesToCopy);
-  if (!std::equal(destination.begin(), destination.end(), mic.buf_1)) {
+  if (!std::equal(destination.begin(), destination.end(), mic.buf_0)) {
     return 6;
   }
 


### PR DESCRIPTION
## Summary
- correct the ping-pong DMA sequence helpers so the ISR returns the buffer that just finished transferring
- update the DMA sequence unit test expectations to reflect the real buffer order reported by the hardware driver

## Testing
- `g++ -std=c++17 tests/test_dma_sequence.cpp Seeed_Arduino_Mic-master/src/hardware/base_mic.cpp -Itests/stubs -ISeeed_Arduino_Mic-master/src -o test_dma_sequence`
- `./test_dma_sequence`
- `g++ -std=c++17 tests/test_base_mic.cpp Seeed_Arduino_Mic-master/src/hardware/base_mic.cpp -Itests/stubs -ISeeed_Arduino_Mic-master/src -o test_base_mic`
- `./test_base_mic`

------
https://chatgpt.com/codex/tasks/task_e_68d8517e57cc8328a7f63d6f240230de