### PR TITLE
Fix DMA buffer selection logic

### DIFF
--- a/Seeed_Arduino_Mic-master/src/hardware/base_mic.cpp
+++ b/Seeed_Arduino_Mic-master/src/hardware/base_mic.cpp
@@ -88,15 +88,14 @@ void MicClass::set_callback(void(*function)(uint16_t *buf, uint32_t buf_len))
 uint16_t *MicClass::completed_buffer_from_sequence(unsigned int sequence_no)
 {
   // The Silicon Labs DMADRV ping-pong helper reports the sequence number of the
-  // descriptor that *started* the transfer that just finished.  This means the
-  // freshly completed audio samples live in the opposite buffer from the one
-  // indicated by the sequence number that the ISR receives.
+  // descriptor that *completed* the transfer.  This means the buffer index
+  // directly matches the descriptor index reported to the ISR.
   const bool completed_primary = (sequence_no % 2u) == 0u;
-  return completed_primary ? buf_1_ptr : buf_0_ptr;
+  return completed_primary ? buf_0_ptr : buf_1_ptr;
 }
 
 uint8_t MicClass::buffer_index_from_sequence(unsigned int sequence_no)
 {
-  return (sequence_no % 2u) == 0u ? 1u : 0u;
+  return (sequence_no % 2u) == 0u ? 0u : 1u;
 }
 


### PR DESCRIPTION
## Summary
- correct the DMA ping-pong completion handling so the ISR reports the buffer that actually finished
- update the inline documentation to match the DMADRV sequence numbering behaviour

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d94ffb6b9c8328b4c8440f0433086b